### PR TITLE
brush: add modal to input ROM file

### DIFF
--- a/brush/package-lock.json
+++ b/brush/package-lock.json
@@ -12230,12 +12230,6 @@
       "version": "file:../scissors",
       "requires": {
         "ramda": "0.26.1"
-      },
-      "dependencies": {
-        "ramda": {
-          "version": "0.26.1",
-          "bundled": true
-        }
       }
     },
     "select-hose": {

--- a/brush/package-lock.json
+++ b/brush/package-lock.json
@@ -12230,6 +12230,12 @@
       "version": "file:../scissors",
       "requires": {
         "ramda": "0.26.1"
+      },
+      "dependencies": {
+        "ramda": {
+          "version": "0.26.1",
+          "bundled": true
+        }
       }
     },
     "select-hose": {

--- a/brush/src/components/Content.js
+++ b/brush/src/components/Content.js
@@ -1,7 +1,7 @@
 import React, { useContext } from 'react'
 import ROMContext from '../context/ROMContext'
 import Map from './map'
-import InputModal from './InputModal';
+import InputROMModal from './InputROMModal'
 
 const Content = () => {
   const { romBuffer } = useContext(ROMContext)
@@ -10,7 +10,7 @@ const Content = () => {
     return <Map />
   }
 
-  return <InputModal />;
+  return <InputROMModal />
 }
 
 export default Content

--- a/brush/src/components/Content.js
+++ b/brush/src/components/Content.js
@@ -1,7 +1,7 @@
 import React, { useContext } from 'react'
 import ROMContext from '../context/ROMContext'
-import InputROM from './InputROM'
 import Map from './map'
+import InputModal from './InputModal';
 
 const Content = () => {
   const { romBuffer } = useContext(ROMContext)
@@ -10,7 +10,7 @@ const Content = () => {
     return <Map />
   }
 
-  return <InputROM />
+  return <InputModal />;
 }
 
 export default Content

--- a/brush/src/components/InputROM.js
+++ b/brush/src/components/InputROM.js
@@ -28,7 +28,7 @@ const InputROM = () => {
 
   return (
     <FileReaderInput as="binary" onChange={handleChange(setROMBuffer)}>
-      <Button>Select the ROM file</Button>
+      <Button>Browse Files</Button>
     </FileReaderInput>
   )
 }

--- a/brush/src/components/InputROMModal.js
+++ b/brush/src/components/InputROMModal.js
@@ -1,0 +1,21 @@
+import React from 'react'
+import InputROM from './InputROM'
+import { Modal, ModalActions, ModalTitle } from 'former-kit'
+
+const InputROMModal = () => {
+  const childrenNode = <div>
+    <ModalTitle
+      title="Please, select your ROM file"
+      titleAlign="center"/>
+    <ModalActions children={<InputROM />} />
+  </div>
+
+  return (
+    <Modal
+      children={childrenNode}
+      isOpen={true}
+    />
+  )
+}
+
+export default InputROMModal

--- a/brush/src/components/InputROMModal.js
+++ b/brush/src/components/InputROMModal.js
@@ -1,21 +1,18 @@
+import { Modal, ModalActions, ModalTitle } from 'former-kit'
 import React from 'react'
 import InputROM from './InputROM'
-import { Modal, ModalActions, ModalTitle } from 'former-kit'
 
-const InputROMModal = () => {
-  const childrenNode = <div>
+const InputROMModal = () => (
+  <Modal isOpen>
     <ModalTitle
       title="Please, select your ROM file"
-      titleAlign="center"/>
-    <ModalActions children={<InputROM />} />
-  </div>
-
-  return (
-    <Modal
-      children={childrenNode}
-      isOpen={true}
+      titleAlign="center"
     />
-  )
-}
+
+    <ModalActions>
+      <InputROM />
+    </ModalActions>
+  </Modal>
+)
 
 export default InputROMModal


### PR DESCRIPTION
Some UI improvements.
Now the main page asks for the ROM file in a modal component, which disappears after the ROM file is uploaded.