### PR TITLE
doc: add docker installation guide on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Since this is a study project, I'm writing a manual about how I'm developing it,
 > git clone https://github.com/macabeus/klo-gba.js.git
 ```
 
-2 - At the project root, compile some webassembly:
+2 - At the project root, compile some webassembly. To run this command, you'll need to have docker installed in your machine, in case you don't, check [Docker official website](https://docs.docker.com/install/):
 
 ```
 > cd klo-gba.js


### PR DESCRIPTION
The project uses docker in order to compile the webassembly code.
This commit adds a warning on the readme for those who may not have
docker installed yet. It also adds an installation guide from docker.com

Fixes issue #5.