### PR TITLE
brush: fix ROMProvider to run useEffect only once

### DIFF
--- a/brush/src/providers/ROMProvider.js
+++ b/brush/src/providers/ROMProvider.js
@@ -24,7 +24,7 @@ const useROMBuffer = () => {
     }
 
     fetchLocalROMBufferMemory()
-  })
+  }, [])
 
   const updateROMBufferState = (newRomBufferMemory) => {
     setROMBufferState(romBufferStates.loaded(newRomBufferMemory))


### PR DESCRIPTION
At `useROMBuffer` provider, we need a `useEffect` to try to fetch the ROM at localStorage. We need to do it only once, but it is run every time.
To fix it, following [this answers](https://stackoverflow.com/a/53121021/3440266), we need to use `[]` to run `useEffect` only once.

Resolves https://github.com/macabeus/klo-gba.js/issues/16