### PR TITLE
brush: add auto erase for MapFooter message and HighlightCoordinates

### DIFF
--- a/brush/src/components/Body.js
+++ b/brush/src/components/Body.js
@@ -4,10 +4,15 @@ import ObjectsTable from './ObjectsTable'
 import ROMContext from '../context/ROMContext'
 import Map from './map'
 import InputROMModal from './InputROMModal'
+import useWhenVisionChanges from '../hooks/useWhenVisionChanges'
 
 const Body = () => {
   const { romBufferStatus } = useContext(ROMContext)
   const [highlightCoordinates, setHighlightCoordinates] = useState([-1, -1])
+
+  useWhenVisionChanges(() => {
+    setHighlightCoordinates([-1, -1])
+  })
 
   const contentStates = {
     empty: <InputROMModal />,

--- a/brush/src/components/map/index.js
+++ b/brush/src/components/map/index.js
@@ -6,6 +6,7 @@ import HighlightCoordinates from './HighlightCoordinates'
 import VisionContext from '../../context/VisionContext'
 import TilemapLayer from './TilemapLayer'
 import OAMLayer from './OAMLayer'
+import useWhenVisionChanges from '../../hooks/useWhenVisionChanges'
 
 const Map = ({ highlightCoordinates }) => {
   const { vision } = useContext(VisionContext) // workaround because a limitation in react-konva (https://github.com/konvajs/react-konva/issues/349)
@@ -19,6 +20,10 @@ const Map = ({ highlightCoordinates }) => {
   } = vision
 
   const [selectedPointInfos, setSelectedPointInfos] = useState(null)
+
+  useWhenVisionChanges(() => {
+    setSelectedPointInfos(null)
+  })
 
   return (
     <Fragment>

--- a/brush/src/hooks/useWhenVisionChanges.js
+++ b/brush/src/hooks/useWhenVisionChanges.js
@@ -1,0 +1,10 @@
+import { useContext, useEffect } from 'react'
+import VisionContext from '../context/VisionContext'
+
+const useWhenVisionChanges = (callback) => {
+  const { visionIndex, visionWorld } = useContext(VisionContext)
+
+  useEffect(callback, [visionIndex, visionWorld])
+}
+
+export default useWhenVisionChanges


### PR DESCRIPTION
Now when the user changes the vision, MapFooter message and HighlightCoordinates will be erase.
To do it, was add a new custom hook, `useWhenVisionChanges`.