### PR TITLE
Add feature to edit the tilemap and save it on the ROM

### DIFF
--- a/brush/src/components/Body.js
+++ b/brush/src/components/Body.js
@@ -25,6 +25,7 @@ const Body = () => {
   const [highlightCoordinates, setHighlightCoordinates] = useState([-1, -1])
   const [showGrid, setShowGrid] = useState(false)
   const [showOAM, setShowOAM] = useState(true)
+  const [selectedTileIdInSet, setSelectedTileIdInSet] = useState(null)
 
   useWhenVisionChanges(() => {
     setHighlightCoordinates([-1, -1])
@@ -69,6 +70,7 @@ const Body = () => {
               (vision.state === 'selected') ?
                 <Map
                   highlightCoordinates={highlightCoordinates}
+                  selectedTileIdInSet={selectedTileIdInSet}
                   showGrid={showGrid}
                   showOAM={showOAM}
                 /> :
@@ -82,7 +84,7 @@ const Body = () => {
         <Card>
           <CardTitle title="Tile Set" />
           <CardContent>
-            <TileSet />
+            <TileSet onSelectTile={setSelectedTileIdInSet} />
           </CardContent>
         </Card>
 

--- a/brush/src/components/Body.js
+++ b/brush/src/components/Body.js
@@ -16,6 +16,7 @@ import VisionContext from '../context/VisionContext'
 import Map from './map'
 import MapEmptyState from './MapEmptyState'
 import InputROMModal from './InputROMModal'
+import SaveButton from './MapActionsBar/SaveButton'
 import TileSet from './TileSet'
 import useWhenVisionChanges from '../hooks/useWhenVisionChanges'
 
@@ -38,6 +39,8 @@ const Body = () => {
         <Card>
           <CardContent>
             <Flexbox justifyContent="flex-end">
+              <SaveButton />
+              <Spacing size="tiny" />
               <Popover
                 content={
                   <PopoverContent>

--- a/brush/src/components/Body.js
+++ b/brush/src/components/Body.js
@@ -16,6 +16,7 @@ import VisionContext from '../context/VisionContext'
 import Map from './map'
 import MapEmptyState from './MapEmptyState'
 import InputROMModal from './InputROMModal'
+import TileSet from './TileSet'
 import useWhenVisionChanges from '../hooks/useWhenVisionChanges'
 
 const Body = () => {
@@ -73,6 +74,15 @@ const Body = () => {
                 /> :
                 <MapEmptyState />
             }
+          </CardContent>
+        </Card>
+
+        <Spacing />
+
+        <Card>
+          <CardTitle title="Tile Set" />
+          <CardContent>
+            <TileSet />
           </CardContent>
         </Card>
 

--- a/brush/src/components/Body.js
+++ b/brush/src/components/Body.js
@@ -17,7 +17,9 @@ import Map from './map'
 import MapEmptyState from './MapEmptyState'
 import InputROMModal from './InputROMModal'
 import SaveButton from './MapActionsBar/SaveButton'
+import SwitchTool from './MapActionsBar/SwitchTool'
 import TileSet from './TileSet'
+import useTool from '../hooks/useTool'
 import useWhenVisionChanges from '../hooks/useWhenVisionChanges'
 
 const Body = () => {
@@ -26,7 +28,7 @@ const Body = () => {
   const [highlightCoordinates, setHighlightCoordinates] = useState([-1, -1])
   const [showGrid, setShowGrid] = useState(false)
   const [showOAM, setShowOAM] = useState(true)
-  const [selectedTileIdInSet, setSelectedTileIdInSet] = useState(null)
+  const [toolState, setToolState] = useTool()
 
   useWhenVisionChanges(() => {
     setHighlightCoordinates([-1, -1])
@@ -39,6 +41,11 @@ const Body = () => {
         <Card>
           <CardContent>
             <Flexbox justifyContent="flex-end">
+              <SwitchTool
+                setToolState={setToolState}
+                toolState={toolState}
+              />
+              <Spacing />
               <SaveButton />
               <Spacing size="tiny" />
               <Popover
@@ -73,9 +80,9 @@ const Body = () => {
               (vision.state === 'selected') ?
                 <Map
                   highlightCoordinates={highlightCoordinates}
-                  selectedTileIdInSet={selectedTileIdInSet}
                   showGrid={showGrid}
                   showOAM={showOAM}
+                  toolState={toolState}
                 /> :
                 <MapEmptyState />
             }
@@ -87,7 +94,7 @@ const Body = () => {
         <Card>
           <CardTitle title="Tile Set" />
           <CardContent>
-            <TileSet onSelectTile={setSelectedTileIdInSet} />
+            <TileSet setToolState={setToolState} />
           </CardContent>
         </Card>
 

--- a/brush/src/components/MapActionsBar/SaveButton.js
+++ b/brush/src/components/MapActionsBar/SaveButton.js
@@ -1,0 +1,44 @@
+import React, { useContext } from 'react'
+import { Button } from 'former-kit'
+import { saveVision } from 'scissors'
+import ROMContext from '../../context/ROMContext'
+import VisionContext from '../../context/VisionContext'
+
+const romDownload = (romBufferMemory, world, index, tilemap) => {
+  const newMemoryROM = saveVision(romBufferMemory, world, index, tilemap)
+
+  const blob = new Blob([newMemoryROM])
+
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  link.setAttribute('href', url)
+  link.setAttribute('download', 'klo-gba.rom')
+  link.style.visibility = 'hidden'
+  document.body.appendChild(link)
+  const event = document.createEvent('MouseEvents')
+  event.initEvent('click', true, true)
+  link.dispatchEvent(event)
+}
+
+const SaveButton = () => {
+  const { romBufferMemory } = useContext(ROMContext)
+  const {
+    vision: {
+      tilemap,
+    },
+    visionIndex,
+    visionWorld,
+  } = useContext(VisionContext)
+
+  return (
+    <Button
+      onClick={() => {
+        romDownload(romBufferMemory, visionWorld, visionIndex, tilemap)
+      }}
+    >
+      Save map
+    </Button>
+  )
+}
+
+export default SaveButton

--- a/brush/src/components/MapActionsBar/SwitchTool.js
+++ b/brush/src/components/MapActionsBar/SwitchTool.js
@@ -1,0 +1,30 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { SegmentedSwitch } from 'former-kit'
+
+const SwitchTool = ({ setToolState, toolState }) => (
+  <SegmentedSwitch
+    name="tool"
+    onChange={(value) => { setToolState(value) }}
+    options={[
+      {
+        title: 'Magnifying Glass',
+        value: 'magnifyingGlass',
+      },
+      {
+        title: 'Brush',
+        value: 'brush',
+      },
+    ]}
+    value={toolState.name}
+  />
+)
+
+SwitchTool.propTypes = {
+  setToolState: PropTypes.func.isRequired,
+  toolState: PropTypes.shape({
+    name: PropTypes.string.isRequired,
+  }).isRequired,
+}
+
+export default SwitchTool

--- a/brush/src/components/TileSet/index.js
+++ b/brush/src/components/TileSet/index.js
@@ -1,4 +1,5 @@
 import React, { useContext } from 'react'
+import PropTypes from 'prop-types'
 import {
   groupBy,
   map,
@@ -11,11 +12,14 @@ import tileNameToColor from '../../constants/tileNameToColor'
 import VisionContext from '../../context/VisionContext'
 import style from './style.css'
 
-const mapTilesIdsToBlock = map(({ id, name }) => (
+const mapTilesIdsToBlock = map(({ id, name, onClickHandle }) => (
+  // TODO: disabling these rules because we are using <p> temporarily until a better UI is developed
+  // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions
   <p
     className={style.block}
     key={`${name} ${id}`}
     style={{ backgroundColor: `rgba(${tileNameToColor[name]})` }}
+    onClick={onClickHandle}
   >
     {id}
   </p>
@@ -28,7 +32,7 @@ const makeTilesGroup = (tiles, name) => (
   </div>
 )
 
-const TileSet = () => {
+const TileSet = ({ onSelectTile }) => {
   const {
     vision: {
       infos: {
@@ -48,6 +52,7 @@ const TileSet = () => {
     |> map(tileId => ({
       id: tileId,
       name: getTileNameById(tileId),
+      onClickHandle: () => { onSelectTile(tileId) },
     }))
     |> groupBy(({ name }) => name)
     |> mapObjIndexed(makeTilesGroup)
@@ -58,6 +63,10 @@ const TileSet = () => {
       {groups}
     </span>
   )
+}
+
+TileSet.propTypes = {
+  onSelectTile: PropTypes.func.isRequired,
 }
 
 export default TileSet

--- a/brush/src/components/TileSet/index.js
+++ b/brush/src/components/TileSet/index.js
@@ -1,0 +1,63 @@
+import React, { useContext } from 'react'
+import {
+  groupBy,
+  map,
+  mapObjIndexed,
+  uniq,
+  values,
+} from 'ramda'
+import { fromSchemeGetTileNameById } from 'scissors'
+import tileNameToColor from '../../constants/tileNameToColor'
+import VisionContext from '../../context/VisionContext'
+import style from './style.css'
+
+const mapTilesIdsToBlock = map(({ id, name }) => (
+  <p
+    className={style.block}
+    key={`${name} ${id}`}
+    style={{ backgroundColor: `rgba(${tileNameToColor[name]})` }}
+  >
+    {id}
+  </p>
+))
+
+const makeTilesGroup = (tiles, name) => (
+  <div className={style.group} key={name}>
+    <h4 className={style.title}>{name}</h4>
+    {mapTilesIdsToBlock(tiles)}
+  </div>
+)
+
+const TileSet = () => {
+  const {
+    vision: {
+      infos: {
+        tilemap: {
+          scheme,
+        },
+      },
+      tilemap,
+    },
+  } = useContext(VisionContext)
+
+  const getTileNameById = fromSchemeGetTileNameById(scheme)
+
+  const groups =
+    tilemap
+    |> uniq
+    |> map(tileId => ({
+      id: tileId,
+      name: getTileNameById(tileId),
+    }))
+    |> groupBy(({ name }) => name)
+    |> mapObjIndexed(makeTilesGroup)
+    |> values
+
+  return (
+    <span className={style.tileSet}>
+      {groups}
+    </span>
+  )
+}
+
+export default TileSet

--- a/brush/src/components/TileSet/index.js
+++ b/brush/src/components/TileSet/index.js
@@ -32,7 +32,7 @@ const makeTilesGroup = (tiles, name) => (
   </div>
 )
 
-const TileSet = ({ onSelectTile }) => {
+const TileSet = ({ setToolState }) => {
   const {
     vision: {
       infos: {
@@ -52,7 +52,7 @@ const TileSet = ({ onSelectTile }) => {
     |> map(tileId => ({
       id: tileId,
       name: getTileNameById(tileId),
-      onClickHandle: () => { onSelectTile(tileId) },
+      onClickHandle: () => { setToolState('brush', tileId) },
     }))
     |> groupBy(({ name }) => name)
     |> mapObjIndexed(makeTilesGroup)
@@ -66,7 +66,7 @@ const TileSet = ({ onSelectTile }) => {
 }
 
 TileSet.propTypes = {
-  onSelectTile: PropTypes.func.isRequired,
+  setToolState: PropTypes.func.isRequired,
 }
 
 export default TileSet

--- a/brush/src/components/TileSet/style.css
+++ b/brush/src/components/TileSet/style.css
@@ -1,0 +1,20 @@
+.tileSet {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.group {
+  width: 85px;
+}
+
+.title {
+  font-weight: bold;
+}
+
+.block {
+  max-height: 50px;
+  max-width: 50px;
+  margin-top: 1px;
+  margin-bottom: 1px;
+  font-family: monospace;
+}

--- a/brush/src/components/map/DrawingLayer/index.js
+++ b/brush/src/components/map/DrawingLayer/index.js
@@ -5,18 +5,16 @@ import { getPointRef } from '../global-state'
 
 const DrawingLayer = ({
   height,
-  selectedTileIdInSet,
+  toolState,
   updateTilemapPoint,
   width,
 }) => {
-  const currentTool = selectedTileIdInSet ?
-    'brush' :
-    'magnifyingGlass'
+  const { name: toolName, value: toolValue } = toolState
 
   const mapToolToFunc = {
     brush: ({ ref, x, y }) => {
-      ref.changeTile(selectedTileIdInSet)
-      updateTilemapPoint(x, y, selectedTileIdInSet)
+      ref.changeTile(toolValue)
+      updateTilemapPoint(x, y, toolValue)
     },
 
     magnifyingGlass: ({ ref }) => {
@@ -26,7 +24,7 @@ const DrawingLayer = ({
 
   const onClickHandler = (x, y) => {
     const ref = getPointRef(x, y)
-    mapToolToFunc[currentTool]({ ref, x, y })
+    mapToolToFunc[toolName]({ ref, x, y })
   }
 
   return (
@@ -45,13 +43,12 @@ const DrawingLayer = ({
 
 DrawingLayer.propTypes = {
   height: PropTypes.number.isRequired,
-  selectedTileIdInSet: PropTypes.number,
+  toolState: PropTypes.shape({
+    name: PropTypes.string.isRequired,
+    value: PropTypes.any,
+  }).isRequired,
   updateTilemapPoint: PropTypes.func.isRequired,
   width: PropTypes.number.isRequired,
-}
-
-DrawingLayer.defaultProps = {
-  selectedTileIdInSet: null,
 }
 
 export default DrawingLayer

--- a/brush/src/components/map/DrawingLayer/index.js
+++ b/brush/src/components/map/DrawingLayer/index.js
@@ -6,6 +6,7 @@ import { getPointRef } from '../global-state'
 const DrawingLayer = ({
   height,
   selectedTileIdInSet,
+  updateTilemapPoint,
   width,
 }) => {
   const currentTool = selectedTileIdInSet ?
@@ -13,8 +14,9 @@ const DrawingLayer = ({
     'magnifyingGlass'
 
   const mapToolToFunc = {
-    brush: ({ ref }) => {
+    brush: ({ ref, x, y }) => {
       ref.changeTile(selectedTileIdInSet)
+      updateTilemapPoint(x, y, selectedTileIdInSet)
     },
 
     magnifyingGlass: ({ ref }) => {
@@ -24,7 +26,7 @@ const DrawingLayer = ({
 
   const onClickHandler = (x, y) => {
     const ref = getPointRef(x, y)
-    mapToolToFunc[currentTool]({ ref })
+    mapToolToFunc[currentTool]({ ref, x, y })
   }
 
   return (
@@ -44,6 +46,7 @@ const DrawingLayer = ({
 DrawingLayer.propTypes = {
   height: PropTypes.number.isRequired,
   selectedTileIdInSet: PropTypes.number,
+  updateTilemapPoint: PropTypes.func.isRequired,
   width: PropTypes.number.isRequired,
 }
 

--- a/brush/src/components/map/DrawingLayer/index.js
+++ b/brush/src/components/map/DrawingLayer/index.js
@@ -1,0 +1,54 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Layer, Rect } from 'react-konva'
+import { getPointRef } from '../global-state'
+
+const DrawingLayer = ({
+  height,
+  selectedTileIdInSet,
+  width,
+}) => {
+  const currentTool = selectedTileIdInSet ?
+    'brush' :
+    'magnifyingGlass'
+
+  const mapToolToFunc = {
+    brush: ({ ref }) => {
+      ref.changeTile(selectedTileIdInSet)
+    },
+
+    magnifyingGlass: ({ ref }) => {
+      ref.clickHandle()
+    },
+  }
+
+  const onClickHandler = (x, y) => {
+    const ref = getPointRef(x, y)
+    mapToolToFunc[currentTool]({ ref })
+  }
+
+  return (
+    <Layer
+      onClick={(e) => {
+        onClickHandler(
+          Math.floor(e.evt.layerX / 4),
+          Math.floor(e.evt.layerY / 4)
+        )
+      }}
+    >
+      <Rect height={height} width={width} />
+    </Layer>
+  )
+}
+
+DrawingLayer.propTypes = {
+  height: PropTypes.number.isRequired,
+  selectedTileIdInSet: PropTypes.number,
+  width: PropTypes.number.isRequired,
+}
+
+DrawingLayer.defaultProps = {
+  selectedTileIdInSet: null,
+}
+
+export default DrawingLayer

--- a/brush/src/components/map/TilemapLayer/index.js
+++ b/brush/src/components/map/TilemapLayer/index.js
@@ -4,6 +4,7 @@ import { Layer } from 'react-konva'
 import { range } from 'ramda'
 import { fromSchemeGetTileNameById } from 'scissors'
 import PointTile from '../point/PointTile'
+import { addPointRef } from '../global-state'
 
 const listCoordinates = (height, width) => {
   const rangeHeight = range(0, height)
@@ -20,11 +21,13 @@ const listCoordinates = (height, width) => {
 const TilemapLayer = ({ setSelectedPointInfos, vision }) => {
   const {
     infos: {
+      index,
       tilemap: {
         height,
         scheme,
         width,
       },
+      world,
     },
     tilemap,
   } = vision
@@ -42,9 +45,11 @@ const TilemapLayer = ({ setSelectedPointInfos, vision }) => {
     }
 
     return (<PointTile
-      key={`${x} ${y}`}
+      key={`${world} ${index} ${x} ${y}`}
       tileName={tileName}
       tileValue={tileValue}
+      getTileNameById={getTileNameById}
+      ref={(instance) => { addPointRef(x, y, instance) }}
       showPointInfosHandle={setSelectedPointInfos}
       x={x}
       y={y}

--- a/brush/src/components/map/TilemapLayer/index.js
+++ b/brush/src/components/map/TilemapLayer/index.js
@@ -1,13 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { Layer } from 'react-konva'
-import {
-  defaultTo,
-  find,
-  pipe,
-  prop,
-  range,
-} from 'ramda'
+import { range } from 'ramda'
+import { fromSchemeGetTileNameById } from 'scissors'
 import PointTile from '../point/PointTile'
 
 const listCoordinates = (height, width) => {
@@ -22,12 +17,6 @@ const listCoordinates = (height, width) => {
   return coordinates
 }
 
-const getTileNameFromScheme = tileValue => pipe(
-  find(({ ids }) => ids.includes(tileValue)),
-  defaultTo({ name: 'unknown' }),
-  prop('name')
-)
-
 const TilemapLayer = ({ setSelectedPointInfos, vision }) => {
   const {
     infos: {
@@ -40,6 +29,8 @@ const TilemapLayer = ({ setSelectedPointInfos, vision }) => {
     tilemap,
   } = vision
 
+  const getTileNameById = fromSchemeGetTileNameById(scheme)
+
   const getPoint = (x, y) => {
     const tileValue = tilemap[x + (y * width)]
 
@@ -47,7 +38,7 @@ const TilemapLayer = ({ setSelectedPointInfos, vision }) => {
     if (tileValue === 0x00) {
       tileName = 'empty'
     } else {
-      tileName = getTileNameFromScheme(tileValue)(scheme)
+      tileName = getTileNameById(tileValue)
     }
 
     return (<PointTile

--- a/brush/src/components/map/global-state.js
+++ b/brush/src/components/map/global-state.js
@@ -1,0 +1,16 @@
+const pointsRefs = {}
+
+const addPointRef = (x, y, ref) => {
+  if (pointsRefs[x] === undefined) {
+    pointsRefs[x] = []
+  }
+
+  pointsRefs[x][y] = ref
+}
+
+const getPointRef = (x, y) => pointsRefs[x][y]
+
+export {
+  addPointRef,
+  getPointRef,
+}

--- a/brush/src/components/map/index.js
+++ b/brush/src/components/map/index.js
@@ -12,9 +12,9 @@ import useWhenVisionChanges from '../../hooks/useWhenVisionChanges'
 
 const Map = ({
   highlightCoordinates,
-  selectedTileIdInSet,
   showGrid,
   showOAM,
+  toolState,
 }) => {
   const { updateTilemapPoint, vision } = useContext(VisionContext) // workaround because a limitation in react-konva (https://github.com/konvajs/react-konva/issues/349)
   const {
@@ -41,7 +41,7 @@ const Map = ({
         />
         <DrawingLayer
           height={height * 4}
-          selectedTileIdInSet={selectedTileIdInSet}
+          toolState={toolState}
           updateTilemapPoint={updateTilemapPoint}
           width={width * 4}
         />
@@ -68,14 +68,16 @@ const Map = ({
 
 Map.propTypes = {
   highlightCoordinates: PropTypes.arrayOf(PropTypes.number),
-  selectedTileIdInSet: PropTypes.number,
   showGrid: PropTypes.bool,
   showOAM: PropTypes.bool,
+  toolState: PropTypes.shape({
+    name: PropTypes.string.isRequired,
+    value: PropTypes.any,
+  }).isRequired,
 }
 
 Map.defaultProps = {
   highlightCoordinates: [-1, -1],
-  selectedTileIdInSet: null,
   showGrid: false,
   showOAM: true,
 }

--- a/brush/src/components/map/index.js
+++ b/brush/src/components/map/index.js
@@ -5,11 +5,17 @@ import MapFooter from '../MapFooter'
 import HighlightCoordinates from './HighlightCoordinates'
 import VisionContext from '../../context/VisionContext'
 import TilemapLayer from './TilemapLayer'
+import DrawingLayer from './DrawingLayer'
 import OAMLayer from './OAMLayer'
 import GridLayer from './GridLayer'
 import useWhenVisionChanges from '../../hooks/useWhenVisionChanges'
 
-const Map = ({ highlightCoordinates, showGrid, showOAM }) => {
+const Map = ({
+  highlightCoordinates,
+  selectedTileIdInSet,
+  showGrid,
+  showOAM,
+}) => {
   const { vision } = useContext(VisionContext) // workaround because a limitation in react-konva (https://github.com/konvajs/react-konva/issues/349)
   const {
     infos: {
@@ -32,6 +38,11 @@ const Map = ({ highlightCoordinates, showGrid, showOAM }) => {
         <TilemapLayer
           setSelectedPointInfos={setSelectedPointInfos}
           vision={vision}
+        />
+        <DrawingLayer
+          height={height * 4}
+          selectedTileIdInSet={selectedTileIdInSet}
+          width={width * 4}
         />
         {showOAM && <OAMLayer
           setSelectedPointInfos={setSelectedPointInfos}
@@ -56,12 +67,14 @@ const Map = ({ highlightCoordinates, showGrid, showOAM }) => {
 
 Map.propTypes = {
   highlightCoordinates: PropTypes.arrayOf(PropTypes.number),
+  selectedTileIdInSet: PropTypes.number,
   showGrid: PropTypes.bool,
   showOAM: PropTypes.bool,
 }
 
 Map.defaultProps = {
   highlightCoordinates: [-1, -1],
+  selectedTileIdInSet: null,
   showGrid: false,
   showOAM: true,
 }

--- a/brush/src/components/map/index.js
+++ b/brush/src/components/map/index.js
@@ -16,7 +16,7 @@ const Map = ({
   showGrid,
   showOAM,
 }) => {
-  const { vision } = useContext(VisionContext) // workaround because a limitation in react-konva (https://github.com/konvajs/react-konva/issues/349)
+  const { updateTilemapPoint, vision } = useContext(VisionContext) // workaround because a limitation in react-konva (https://github.com/konvajs/react-konva/issues/349)
   const {
     infos: {
       tilemap: {
@@ -42,6 +42,7 @@ const Map = ({
         <DrawingLayer
           height={height * 4}
           selectedTileIdInSet={selectedTileIdInSet}
+          updateTilemapPoint={updateTilemapPoint}
           width={width * 4}
         />
         {showOAM && <OAMLayer

--- a/brush/src/components/map/point/PointTile.js
+++ b/brush/src/components/map/point/PointTile.js
@@ -4,28 +4,58 @@ import { pipe } from 'ramda'
 import tileNameToColor from '../../../constants/tileNameToColor'
 import Point from '.'
 
-const PointTile = ({
-  showPointInfosHandle,
-  tileName,
-  tileValue,
-  x,
-  y,
-}) => {
-  const getInformations = () => ({
-    message: `Tile ${tileName} (${tileValue})`,
-    x,
-    y,
-  })
+// This component should be a class because we need to get a ref of each point to set it in map-global-state
+class PointTile extends React.Component {
+  constructor (props) {
+    super(props)
 
-  return (<Point
-    color={`rgba(${tileNameToColor[tileName]})`}
-    onClickHandle={pipe(getInformations, showPointInfosHandle)}
-    x={x}
-    y={y}
-  />)
+    this.state = {
+      tileName: props.tileName,
+      tileValue: props.tileValue,
+    }
+
+    this.clickHandle = this.clickHandle.bind(this)
+    this.changeTile = this.changeTile.bind(this)
+  }
+
+  clickHandle () {
+    const { x, y } = this.props
+    const { tileName, tileValue } = this.state
+
+    const getInformations = () => ({
+      message: `Tile ${tileName} (${tileValue})`,
+      x,
+      y,
+    })
+
+    pipe(getInformations, this.props.showPointInfosHandle)()
+  }
+
+  changeTile (newTileValue) {
+    const { getTileNameById } = this.props
+
+    const newTileName = getTileNameById(newTileValue)
+
+    this.setState({
+      tileName: newTileName,
+      tileValue: newTileValue,
+    })
+  }
+
+  render () {
+    const { x, y } = this.props
+    const { tileName } = this.state
+
+    return (<Point
+      color={`rgba(${tileNameToColor[tileName]})`}
+      x={x}
+      y={y}
+    />)
+  }
 }
 
 PointTile.propTypes = {
+  getTileNameById: PropTypes.func.isRequired,
   showPointInfosHandle: PropTypes.func,
   tileName: PropTypes.string.isRequired,
   tileValue: PropTypes.number.isRequired,

--- a/brush/src/components/map/point/PointTile.js
+++ b/brush/src/components/map/point/PointTile.js
@@ -1,21 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { pipe } from 'ramda'
+import tileNameToColor from '../../../constants/tileNameToColor'
 import Point from '.'
-
-const mapTileNameToColor = {
-  board: '199, 199, 199, 1',
-  bridge: '200, 131, 63, 1',
-  bridgeRope: '200, 131, 63, 0.5',
-  darkRock: '90, 60, 63, 1',
-  empty: '255, 255, 255, 0',
-  grass: '0, 125, 0, 1',
-  lightRock: '200, 100, 63, 1',
-  rock: '160, 60, 63, 1',
-  spike: '200, 20, 70, 1',
-  unknown: '0, 0, 0, 1',
-  wood: '188, 111, 93, 1',
-}
 
 const PointTile = ({
   showPointInfosHandle,
@@ -31,7 +18,7 @@ const PointTile = ({
   })
 
   return (<Point
-    color={`rgba(${mapTileNameToColor[tileName]})`}
+    color={`rgba(${tileNameToColor[tileName]})`}
     onClickHandle={pipe(getInformations, showPointInfosHandle)}
     x={x}
     y={y}

--- a/brush/src/constants/tileNameToColor.js
+++ b/brush/src/constants/tileNameToColor.js
@@ -1,0 +1,15 @@
+const tileNameToColor = {
+  board: '199, 199, 199, 1',
+  bridge: '200, 131, 63, 1',
+  bridgeRope: '200, 131, 63, 0.5',
+  darkRock: '90, 60, 63, 1',
+  empty: '255, 255, 255, 0',
+  grass: '0, 125, 0, 1',
+  lightRock: '200, 100, 63, 1',
+  rock: '160, 60, 63, 1',
+  spike: '200, 20, 70, 1',
+  unknown: '0, 0, 0, 1',
+  wood: '188, 111, 93, 1',
+}
+
+export default tileNameToColor

--- a/brush/src/hooks/useTool.js
+++ b/brush/src/hooks/useTool.js
@@ -1,0 +1,37 @@
+import { useState } from 'react'
+
+const useTool = () => {
+  const [{ currentTool, toolsValue }, setToolsStates] = useState({
+    currentTool: 'magnifyingGlass',
+    toolsValue: {
+      brush: null,
+      magnifyingGlass: null,
+    },
+  })
+
+  const updateToolState = (tool, newToolState) => {
+    if (newToolState !== undefined) {
+      setToolsStates({
+        currentTool: tool,
+        toolsValue: {
+          ...toolsValue,
+          [tool]: newToolState,
+        },
+      })
+
+      return
+    }
+
+    setToolsStates({
+      currentTool: tool,
+      toolsValue,
+    })
+  }
+
+  return [{
+    name: currentTool,
+    value: toolsValue[currentTool],
+  }, updateToolState]
+}
+
+export default useTool

--- a/brush/src/providers/VisionProvider.js
+++ b/brush/src/providers/VisionProvider.js
@@ -25,8 +25,13 @@ const VisionProvider = (props) => {
     setVision(newVision)
   }
 
+  const updateTilemapPoint = (x, y, newTileId) => {
+    vision.tilemap[x + (y * vision.infos.tilemap.width)] = newTileId
+  }
+
   return (
     <VisionContext.Provider value={{
+        updateTilemapPoint,
         vision,
         visionIndex,
         visionUpdate,

--- a/brush/src/providers/VisionProvider.js
+++ b/brush/src/providers/VisionProvider.js
@@ -8,7 +8,7 @@ const VisionProvider = (props) => {
   const [visionIndex, setVisionIndex] = useState(1)
 
   const [vision, setVision] = useState({
-    infos: { tilemap: { height: 0, scheme: [], width: 0 } },
+    infos: { index: 0, tilemap: { height: 0, scheme: [], width: 0 }, world: 0 },
     oam: [],
     state: 'noSelected',
     tilemap: new Uint8Array(),
@@ -20,6 +20,8 @@ const VisionProvider = (props) => {
 
     const newVision = scissors.getVision(romBuffer, world, index)
     newVision.state = 'selected'
+    newVision.infos.world = world
+    newVision.infos.index = index
     setVision(newVision)
   }
 

--- a/scissors/src/from-scheme-get-tile-name-by-id.js
+++ b/scissors/src/from-scheme-get-tile-name-by-id.js
@@ -1,0 +1,14 @@
+import {
+  defaultTo,
+  find,
+  pipe,
+  prop,
+} from 'ramda'
+
+const fromSchemeGetTileNameById = scheme => id => pipe(
+  find(({ ids }) => ids.includes(id)),
+  defaultTo({ name: 'unknown' }),
+  prop('name')
+)(scheme)
+
+export default fromSchemeGetTileNameById

--- a/scissors/src/get-vision.js
+++ b/scissors/src/get-vision.js
@@ -1,6 +1,6 @@
 import { drop, splitEvery, map, filter } from 'ramda'
 import binary from 'binary'
-import huffmanDecode from './huffman'
+import { huffmanDecode } from './huffman'
 import { lzssDecode } from './lzss'
 
 const extractTilemap = (romBuffer, [addressStart, addressEnd]) =>

--- a/scissors/src/get-vision.js
+++ b/scissors/src/get-vision.js
@@ -1,7 +1,7 @@
 import { drop, splitEvery, map, filter } from 'ramda'
 import binary from 'binary'
 import huffmanDecode from './huffman'
-import lzssDecode from './lzss'
+import { lzssDecode } from './lzss'
 
 const extractTilemap = (romBuffer, [addressStart, addressEnd]) =>
   romBuffer.slice(addressStart, addressEnd)

--- a/scissors/src/huffman.js
+++ b/scissors/src/huffman.js
@@ -33,4 +33,19 @@ const huffmanDecode = (buffer) => {
   }
 }
 
-export default huffmanDecode
+const huffmanEncode = (buffer) => {
+  FS.writeFile('input_huffman_encode', buffer)
+
+  huffmanModule._HUF_Encode() // eslint-disable-line no-underscore-dangle
+
+  try {
+    return huffmanModule.FS.readFile('output_huffman_encode', { encoding: 'binary' })
+  } catch (e) {
+    throw new HuffmanDecodeError(e)
+  }
+}
+
+export {
+  huffmanDecode,
+  huffmanEncode,
+}

--- a/scissors/src/index.js
+++ b/scissors/src/index.js
@@ -1,7 +1,10 @@
 import getVision from './get-vision'
 import { oamIdToName } from './oam-maps'
+import fromSchemeGetTileNameById from './from-scheme-get-tile-name-by-id'
 
 export default {
   getVision,
   oamIdToName,
 }
+
+export { fromSchemeGetTileNameById }

--- a/scissors/src/index.js
+++ b/scissors/src/index.js
@@ -1,4 +1,4 @@
-import getVision from './get-vision'
+import { getVision, saveVision } from './vision-manager'
 import { oamIdToName } from './oam-maps'
 import fromSchemeGetTileNameById from './from-scheme-get-tile-name-by-id'
 
@@ -7,4 +7,7 @@ export default {
   oamIdToName,
 }
 
-export { fromSchemeGetTileNameById }
+export {
+  fromSchemeGetTileNameById,
+  saveVision,
+}

--- a/scissors/src/lzss.js
+++ b/scissors/src/lzss.js
@@ -33,4 +33,19 @@ const lzssDecode = (buffer) => {
   }
 }
 
-export default lzssDecode
+const lzssEncode = (buffer) => {
+  FS.writeFile('input_lzss_encode', buffer)
+
+  lzssModule._LZS_Encode() // eslint-disable-line no-underscore-dangle
+
+  try {
+    return lzssModule.FS.readFile('output_lzss_encode', { encoding: 'binary' })
+  } catch (e) {
+    throw new LzssDecodeError(e)
+  }
+}
+
+export {
+  lzssDecode,
+  lzssEncode,
+}

--- a/scissors/src/wasm/huffman.c
+++ b/scissors/src/wasm/huffman.c
@@ -25,8 +25,8 @@
 #include <emscripten.h>
 
 /*----------------------------------------------------------------------------*/
-int findSize() {
-  FILE *fp = fopen("file", "rb");
+int findSize(char *filename) {
+  FILE *fp = fopen(filename, "rb");
   fseek(fp, 0, SEEK_END);
   int lengthOfFile = ftell(fp);
   fclose(fp);
@@ -114,7 +114,7 @@ void  Save(char *filename, char *buffer, int length);
 char *Memory(int length, int size);
 
 void  HUF_Decode();
-void  HUF_Encode(char *filename, int cmd);
+void  HUF_Encode();
 char *HUF_Code(unsigned char *raw_buffer, int raw_len, int *new_len);
 
 void  HUF_InitFreqs(void);
@@ -172,7 +172,7 @@ char *Load(char *filename, int *length, int min, int max) {
   char *fb;
 
   if ((fp = fopen(filename, "rb")) == NULL) EXIT("\nFile open error\n");
-  fs = findSize();
+  fs = findSize(filename);
   if ((fs < min) || (fs > max)) EXIT("\nFile size error\n");
   fb = Memory(fs + 3, sizeof(char));
   if (fread(fb, 1, fs, fp) != fs) EXIT("\nFile read error\n");
@@ -279,15 +279,14 @@ void EMSCRIPTEN_KEEPALIVE HUF_Decode() {
 }
 
 /*----------------------------------------------------------------------------*/
-void HUF_Encode(char *filename, int cmd) {
+void EMSCRIPTEN_KEEPALIVE HUF_Encode() {
+  int cmd = CMD_CODE_20;
   unsigned char *raw_buffer, *pak_buffer, *new_buffer;
   unsigned int   raw_len, pak_len, new_len;
 
-  printf("- encoding '%s'", filename);
-
   num_bits = cmd & 0xF;
 
-  raw_buffer = Load(filename, &raw_len, RAW_MINIM, RAW_MAXIM);
+  raw_buffer = Load("input_huffman_encode", &raw_len, RAW_MINIM, RAW_MAXIM);
 
   pak_buffer = NULL;
   pak_len = HUF_MAXIM + 1;
@@ -325,12 +324,10 @@ void HUF_Encode(char *filename, int cmd) {
     pak_len = new_len;
   }
 
-  Save(filename, pak_buffer, pak_len);
+  Save("output_huffman_encode", pak_buffer, pak_len);
 
   free(pak_buffer);
   free(raw_buffer);
-
-  printf("\n");
 }
 
 /*----------------------------------------------------------------------------*/

--- a/scissors/src/wasm/lzss.c
+++ b/scissors/src/wasm/lzss.c
@@ -25,8 +25,8 @@
 #include <emscripten.h>
 
 /*----------------------------------------------------------------------------*/
-int findSize() {
-  FILE *fp = fopen("filelzss", "rb");
+int findSize(char *filename) {
+  FILE *fp = fopen(filename, "rb");
   fseek(fp, 0, SEEK_END);
   int lengthOfFile = ftell(fp);
   fclose(fp);
@@ -99,7 +99,7 @@ void  Save(char *filename, char *buffer, int length);
 char *Memory(int length, int size);
 
 void  LZS_Decode();
-void  LZS_Encode(char *filename, int mode);
+void  LZS_Encode();
 char *LZS_Code(unsigned char *raw_buffer, int raw_len, int *new_len, int best);
 
 char *LZS_Fast(unsigned char *raw_buffer, int raw_len, int *new_len);
@@ -143,7 +143,7 @@ char *Load(char *filename, int *length, int min, int max) {
   char *fb;
 
   if ((fp = fopen(filename, "rb")) == NULL) EXIT("\nFile open error\n");
-  fs = findSize();
+  fs = findSize(filename);
   if ((fs < min) || (fs > max)) EXIT("\nFile size error\n");
   fb = Memory(fs + 3, sizeof(char));
   if (fread(fb, 1, fs, fp) != fs) EXIT("\nFile read error\n");
@@ -233,15 +233,14 @@ void EMSCRIPTEN_KEEPALIVE LZS_Decode() {
 }
 
 /*----------------------------------------------------------------------------*/
-void LZS_Encode(char *filename, int mode) {
+void EMSCRIPTEN_KEEPALIVE LZS_Encode() {
+  int mode = LZS_WRAM;
   unsigned char *raw_buffer, *pak_buffer, *new_buffer;
   unsigned int   raw_len, pak_len, new_len;
 
   lzs_vram = mode & 0xF;
 
-  printf("- encoding '%s'", filename);
-
-  raw_buffer = Load(filename, &raw_len, RAW_MINIM, RAW_MAXIM);
+  raw_buffer = Load("input_lzss_encode", &raw_len, RAW_MINIM, RAW_MAXIM);
 
   pak_buffer = NULL;
   pak_len = LZS_MAXIM + 1;
@@ -258,12 +257,10 @@ void LZS_Encode(char *filename, int mode) {
     pak_len = new_len;
   }
 
-  Save(filename, pak_buffer, pak_len);
+  Save("output_lzss_encode", pak_buffer, pak_len);
 
   free(pak_buffer);
   free(raw_buffer);
-
-  printf("\n");
 }
 
 /*----------------------------------------------------------------------------*/


### PR DESCRIPTION
Now, finally we can create own vision editing a tilemap and save it on the ROM to play it!
This PR is very huge (sorry about that), adding many things in order to do it be possible:
- some refactors important to the new commits on this PR
- add component `TileSet` which user can use it to select the tile that wants to paint
- add component `SwitchTool` which user can use it to switch between the tools `magnifying glass` and `brush`
- add wrappers to functions from C code: `LZS_Encode` and `HUF_Encode`. These functions is important to compress the new tilemap and save it on ROM, that is make by `saveVision` function

![image](https://user-images.githubusercontent.com/9501115/56939423-9cf38600-6ade-11e9-9ea6-288356f0fb60.png)
