### PR TITLE
rom-load: add error if trying to load a non supported rom region

### DIFF
--- a/brush/package-lock.json
+++ b/brush/package-lock.json
@@ -1770,9 +1770,9 @@
       "dev": true
     },
     "airbnb-prop-types": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/airbnb-prop-types/-/airbnb-prop-types-2.12.0.tgz",
-      "integrity": "sha512-EJLaLf0Rjg+AouOgIBlO1rerwgwu3Y0dwxp7BWzUemY9J1UPO9XOlMmOXzpaHW9O0RzpofiThVl0sIToHtLPAQ==",
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/airbnb-prop-types/-/airbnb-prop-types-2.13.2.tgz",
+      "integrity": "sha512-2FN6DlHr6JCSxPPi25EnqGaXC4OC3/B3k1lCd6MMYrZ51/Gf/1qDfaR+JElzWa+Tl7cY2aYOlsYJGFeQyVHIeQ==",
       "requires": {
         "array.prototype.find": "^2.0.4",
         "function.prototype.name": "^1.1.0",
@@ -1781,9 +1781,16 @@
         "object-is": "^1.0.1",
         "object.assign": "^4.1.0",
         "object.entries": "^1.1.0",
-        "prop-types": "^15.6.2",
+        "prop-types": "^15.7.2",
         "prop-types-exact": "^1.2.0",
-        "react-is": "^16.8.1"
+        "react-is": "^16.8.6"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "16.8.6",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
+          "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA=="
+        }
       }
     },
     "ajv": {
@@ -3805,9 +3812,9 @@
       }
     },
     "direction": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/direction/-/direction-1.0.2.tgz",
-      "integrity": "sha512-hSKoz5FBn+zhP9vWKkVQaaxnRDg3/MoPdcg2au54HIUDR8MrP8Ah1jXSJwCXel6SV3Afh5DSzc8Uqv2r1UoQwQ=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/direction/-/direction-1.0.3.tgz",
+      "integrity": "sha512-8bHRqMt4w/kND19KBksE4NOJo+gIOPuiZfxQvbd6xikfKbuNBYBdLIw0hA/4lWzBaDpwpW+Olmg1BjD9+0LU2w=="
     },
     "dns-equal": {
       "version": "1.0.0",
@@ -3841,6 +3848,14 @@
       "dev": true,
       "requires": {
         "esutils": "^2.0.2"
+      }
+    },
+    "document.contains": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/document.contains/-/document.contains-1.0.1.tgz",
+      "integrity": "sha512-A1KqlZq1w605bwiiLqVZehWE9S9UYlUXPoduFWi64pNVNQ9vy6wwH/7BS+iEfSlF1YyZgcg5PZw5HqDi7FCrUw==",
+      "requires": {
+        "define-properties": "^1.1.3"
       }
     },
     "dom-converter": {
@@ -8189,9 +8204,9 @@
       "optional": true
     },
     "nanoid": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.0.1.tgz",
-      "integrity": "sha512-k1u2uemjIGsn25zmujKnotgniC/gxQ9sdegdezeDiKdkDW56THUMqlz3urndKCXJxA6yPzSZbXx/QCMe/pxqsA=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.0.2.tgz",
+      "integrity": "sha512-X4yQ8VHoFvHcykGunT2Jxrsm1c4vH5UKtau7LLJYXO1istCRE3jD8JxDyGCzN+h7dpWBCvWaSYgloRuphKRqUQ=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -11846,14 +11861,15 @@
       }
     },
     "react-outside-click-handler": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/react-outside-click-handler/-/react-outside-click-handler-1.2.2.tgz",
-      "integrity": "sha512-MgCxmFARGN1VrZdwoLkER/y3So6mC/fSniXI4XcXcB+Jt05nw/k8a/R1hSoa7p414uZUZ8NfClN3eVmZm9bM5Q==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/react-outside-click-handler/-/react-outside-click-handler-1.2.3.tgz",
+      "integrity": "sha512-4orkx59ais0mM/j1Ekc5ewyRu5xNLX4a6pMs7RT8U7JkbPOlRsucE+190kXzYUUHsGfZvyAmsdQkL7lpqzMGBg==",
       "requires": {
-        "airbnb-prop-types": "^2.10.0",
+        "airbnb-prop-types": "^2.12.0",
         "consolidated-events": "^1.1.1 || ^2.0.0",
-        "object.values": "^1.0.4",
-        "prop-types": "^15.6.1"
+        "document.contains": "^1.0.0",
+        "object.values": "^1.1.0",
+        "prop-types": "^15.7.2"
       }
     },
     "react-portal": {
@@ -12458,6 +12474,7 @@
       "version": "file:../scissors",
       "requires": {
         "binary": "0.3.0",
+        "js-sha1": "0.6.0",
         "ramda": "0.26.1"
       }
     },

--- a/brush/package.json
+++ b/brush/package.json
@@ -16,6 +16,7 @@
     "@babel/polyfill": "7.2.5",
     "@babel/runtime": "7.3.4",
     "@babel/plugin-transform-runtime": "7.3.4",
+    "emblematic-icons": "0.6.1",
     "former-kit-skin-pagarme": "1.0.0",
     "former-kit": "1.0.1",
     "gh-pages": "2.0.1",

--- a/brush/src/components/InputRom/InputRomButton.js
+++ b/brush/src/components/InputRom/InputRomButton.js
@@ -1,7 +1,11 @@
-import React, { useContext } from 'react'
-import { Button } from 'former-kit'
+import React, { useContext, useState } from 'react'
+import { Alert, Button, Flexbox } from 'former-kit'
+import IconClose from 'emblematic-icons/svg/ClearClose32.svg'
+import { getRomRegion, isSupportedRegion } from 'scissors'
 import FileReaderInput from 'react-file-reader-input'
+import RomRegionNotSupported from '../../errors/romRegioNotSupported'
 import ROMContext from '../../context/ROMContext'
+import style from './style.css'
 
 const getFileContent = async file =>
   new Promise((resolve, reject) => {
@@ -12,24 +16,52 @@ const getFileContent = async file =>
     }
 
     reader.onload = (ev) => {
-      const buffer = ev.target.result
-      resolve(new Uint8Array(buffer))
+      const buffer = new Uint8Array(ev.target.result)
+
+      const region = getRomRegion(buffer)
+
+      if (isSupportedRegion(region)) {
+        resolve(buffer)
+        return
+      }
+
+      reject(new RomRegionNotSupported(region))
     }
 
     reader.readAsArrayBuffer(file)
   })
 
-const handleChange = setROMBuffer => async (event, [[, file]]) =>
-  (await getFileContent(file))
-  |> setROMBuffer
+const handleChange = (setROMBuffer, onErrorHandle) =>
+  async (event, [[, file]]) => {
+    let fileContent
+
+    try {
+      fileContent = await getFileContent(file)
+    } catch (e) {
+      onErrorHandle(e)
+      return
+    }
+
+    setROMBuffer(fileContent)
+  }
 
 const InputROM = () => {
   const { setROMBuffer } = useContext(ROMContext)
+  const [error, setError] = useState(null)
 
   return (
-    <FileReaderInput as="binary" onChange={handleChange(setROMBuffer)}>
-      <Button>Browse Files</Button>
-    </FileReaderInput>
+    <Flexbox justifyContent="center" className={style.alertMargin}>
+      {
+        error &&
+        <Alert type="error" icon={<IconClose height={16} width={16} />}>
+          <p><strong>Error.</strong> {error.message}</p>
+        </Alert>
+      }
+
+      <FileReaderInput as="binary" onChange={handleChange(setROMBuffer, setError)}>
+        <Button>Browse Files</Button>
+      </FileReaderInput>
+    </Flexbox>
   )
 }
 

--- a/brush/src/components/InputRom/style.css
+++ b/brush/src/components/InputRom/style.css
@@ -1,0 +1,5 @@
+@import "former-kit-skin-pagarme/dist/styles/spacing.css";
+
+.alertMargin > :nth-child(2) {
+  margin-top: var(--spacing-tiny);
+}

--- a/brush/src/errors/romRegioNotSupported.js
+++ b/brush/src/errors/romRegioNotSupported.js
@@ -1,0 +1,19 @@
+import { supportedRomRegions } from 'scissors'
+
+const supportedRomRegionsMessage = supportedRomRegions.join(', ')
+
+class RomRegionNotSupported extends Error {
+  constructor (region) {
+    let message
+    if (region === 'unknown') {
+      message = `This ROM is not supported. Please, send a ROM which region is one of these: ${supportedRomRegionsMessage}`
+    } else {
+      message = `The ROM region ${region} is not supported. Currently, we only support: ${supportedRomRegionsMessage}`
+    }
+
+    super(message)
+    this.code = 'romRegionNotSupported'
+  }
+}
+
+export default RomRegionNotSupported

--- a/scissors/package-lock.json
+++ b/scissors/package-lock.json
@@ -3413,6 +3413,11 @@
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
+    "js-sha1": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/js-sha1/-/js-sha1-0.6.0.tgz",
+      "integrity": "sha512-01gwBFreYydzmU9BmZxpVk6svJJHrVxEN3IOiGl6VO93bVKYETJ0sIth6DASI6mIFdt7NmfX9UiByRzsYHGU9w=="
+    },
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",

--- a/scissors/package.json
+++ b/scissors/package.json
@@ -12,6 +12,7 @@
   "license": "MIT",
   "dependencies": {
     "binary": "0.3.0",
+    "js-sha1": "0.6.0",
     "ramda": "0.26.1"
   },
   "devDependencies": {

--- a/scissors/src/index.js
+++ b/scissors/src/index.js
@@ -1,10 +1,14 @@
 import { getVision, saveVision } from './visionManager'
 import { oamIdToName } from './oamMaps'
 import fromSchemeGetTileNameById from './fromSchemeGetTileNameById'
+import { getRomRegion, supportedRomRegions, isSupportedRegion } from './romRegion'
 
 export {
   fromSchemeGetTileNameById,
   getVision,
   oamIdToName,
   saveVision,
+  getRomRegion,
+  supportedRomRegions,
+  isSupportedRegion,
 }

--- a/scissors/src/romRegion.js
+++ b/scissors/src/romRegion.js
@@ -1,0 +1,21 @@
+import { defaultTo } from 'ramda'
+import sha1 from 'js-sha1'
+
+const getRomRegion = (buffer) => {
+  const hash = sha1(buffer)
+
+  const hashToRegion = {
+    a0a298d9dba1ba15d04a42fc2eb35893d1a9569b: 'usa',
+    e4a81713b134e0b7409708843dad2a4948b903ef: 'europe',
+    f46410ec245dbb6fa90285c6d4071c09cc983b05: 'japan',
+  }
+
+  const region = defaultTo('unknown', hashToRegion[hash])
+  return region
+}
+
+const supportedRomRegions = ['usa']
+
+const isSupportedRegion = region => supportedRomRegions.includes(region)
+
+export { getRomRegion, supportedRomRegions, isSupportedRegion }


### PR DESCRIPTION
Closes https://github.com/macabeus/klo-gba.js/issues/36

This PR adds an alert when the user is trying to upload a ROM that isn't not supported.
To do it, `scissors` now calculates the hash of the ROM and check if it `usa` or not.

![image](https://user-images.githubusercontent.com/9501115/58064481-af4e6600-7b58-11e9-949c-b734589b3cde.png)
