### PR TITLE
save-button: fix default filename extension

### DIFF
--- a/brush/src/components/MapActionsBar/SaveButton.js
+++ b/brush/src/components/MapActionsBar/SaveButton.js
@@ -12,7 +12,7 @@ const romDownload = (romBufferMemory, world, index, tilemap) => {
   const url = URL.createObjectURL(blob)
   const link = document.createElement('a')
   link.setAttribute('href', url)
-  link.setAttribute('download', 'klo-gba.rom')
+  link.setAttribute('download', 'klo-gba.gba')
   link.style.visibility = 'hidden'
   document.body.appendChild(link)
   const event = document.createEvent('MouseEvents')


### PR DESCRIPTION
Some emulator only can open ".gba" files