### PR TITLE
[vision-manager] N-ary vision crashes when saving a tilemap for vision N-1

### DIFF
--- a/scissors/src/rom.js
+++ b/scissors/src/rom.js
@@ -1,0 +1,67 @@
+import { allVisions } from './visions'
+
+const mapAddressToRomOffset = hexValue => hexValue + 0x08000000
+
+const split24LengthHexIntoBytesArray = (hexValue) => {
+  /* eslint-disable no-bitwise */
+  const firstByte = (hexValue >> 24)
+  const secondByte = (hexValue >> 16) & 0xff
+  const thirdByte = (hexValue >> 8) & 0xff
+  const fourthByte = hexValue & 0xff
+  /* eslint-enable no-bitwise */
+
+  return [firstByte, secondByte, thirdByte, fourthByte]
+}
+
+const visionHasCustomTilemap = (romBuffer, visionInfo) =>
+  romBuffer[visionInfo.rom.customTilemap] !== 0x00
+
+const setConstant = (romBuffer, address, value24hexLength) => {
+  const bytes = split24LengthHexIntoBytesArray(value24hexLength)
+  romBuffer.set(bytes.reverse(), address)
+}
+
+const setPatchCustomVisionLoader = (romBuffer) => {
+  const visionsWithCustomTilemap = allVisions.map(visionInfo =>
+    visionHasCustomTilemap(romBuffer, visionInfo))
+
+  const addresses = allVisions.map(visionInfo => ({
+    custom: mapAddressToRomOffset(visionInfo.rom.customTilemap),
+    original: mapAddressToRomOffset(visionInfo.rom.tilemap[0]),
+  }))
+
+  // set bl to go to our patch
+  romBuffer.set([0x23, 0xF3, 0x80, 0xFD], 0x43B0C) // bl 08367610h
+
+  // switch to arm mode and run our code
+  romBuffer.set([0x78, 0x46], 0x367610) // mov r0,r15
+  romBuffer.set([0x3C, 0x30], 0x367612) // add r0, 3Ch
+  romBuffer.set([0x00, 0x47], 0x367614) // bx r0
+
+  // write original and custom address of each vision
+  addresses.forEach(({ custom, original }, index) => {
+    const offset = 0x367620 + (index * 8)
+
+    setConstant(romBuffer, offset, original)
+    setConstant(romBuffer, offset + 4, custom)
+  })
+
+  // change value at R0 to custom address if need
+  romBuffer.set([0x04, 0x00, 0x85, 0xE2], 0x367650) // add r0, r5, 4h
+
+  addresses.forEach((_, index) => {
+    if (visionsWithCustomTilemap[index]) {
+      const offset1 = 0x3C + ((index * 12) - (index * 8))
+      const offset2 = 0x40 + ((index * 12) - (index * 8))
+
+      romBuffer.set([offset1, 0x40, 0x1F, 0xE5], 0x367654 + (index * 12)) // ldr r4,[r15,#-offset1]
+      romBuffer.set([0x04, 0x00, 0x50, 0xE1], 0x367658 + (index * 12)) // cmp r0, r4
+      romBuffer.set([offset2, 0x00, 0x1F, 0x05], 0x36765C + (index * 12)) // ldreq r0,[r15,#-offset2]
+    }
+  })
+
+  romBuffer.set([0x01, 0x40, 0xA0, 0xE1], 0x367660 + (addresses.length * 12)) // mov r4, r1
+  romBuffer.set([0x1E, 0xFF, 0x2F, 0xE1], 0x367664 + (addresses.length * 12)) // bx r14
+}
+
+export { setPatchCustomVisionLoader }

--- a/scissors/src/visionManager.js
+++ b/scissors/src/visionManager.js
@@ -11,6 +11,7 @@ import binary from 'binary'
 import { huffmanDecode, huffmanEncode } from './huffman'
 import { lzssDecode, lzssEncode } from './lzss'
 import { loadVisionInfo } from './visions'
+import { setPatchCustomVisionLoader } from './rom'
 
 const isNumeric = pipe(t => Number(t), identical(NaN), not)
 
@@ -121,10 +122,12 @@ const compressTilemap = buffer =>
 
 const saveVision = (romBuffer, world, index, tilemap) => {
   const infos = loadVisionInfo(world, index)
-  const [addressStart] = infos.rom.tilemap
+  const customTilemapAddress = infos.rom.customTilemap
 
   const encoded = compressTilemap(tilemap)
-  romBuffer.set(encoded, addressStart)
+  romBuffer.set(encoded, customTilemapAddress)
+
+  setPatchCustomVisionLoader(romBuffer)
 
   return romBuffer
 }

--- a/scissors/src/visions/1-1.js
+++ b/scissors/src/visions/1-1.js
@@ -6,6 +6,7 @@ export default {
   },
   rom: {
     tilemap: [0x1B27FC, 0x1B36F3],
+    customTilemap: 0x367700,
     oam: [0xE2B90, 0xE2F59],
     portals: [0xD48C8, 0xD48EF],
   },

--- a/scissors/src/visions/1-2.js
+++ b/scissors/src/visions/1-2.js
@@ -6,6 +6,7 @@ export default {
   },
   rom: {
     tilemap: [0x1B3E5C, 0x1B4AC3],
+    customTilemap: 0x3686B0,
     oam: [0xE3CC0, 0xE3FAC],
     portals: [0xD4970, 0xD49A0],
   },

--- a/scissors/src/visions/1-3.js
+++ b/scissors/src/visions/1-3.js
@@ -6,6 +6,7 @@ export default {
   },
   rom: {
     tilemap: [0x1B50AC, 0x1B5ECC],
+    customTilemap: 0x369380,
     oam: [0xE4DF0, 0xE5109],
     portals: [0xD4A18, 0xD4A5F],
   },


### PR DESCRIPTION
Closes https://github.com/macabeus/klo-gba.js/issues/34

The approach to resolve this bug was to patch the original code to load the visions.
Instead of loading the tilemap at the original address, we redirect it to load the tilemap in another memory region that now we are using to save the custom tilemaps.