### PR TITLE
[Tools] Rename "magnifying glass" to "inspector"

### DIFF
--- a/brush/src/components/Map/DrawingLayer/index.js
+++ b/brush/src/components/Map/DrawingLayer/index.js
@@ -27,7 +27,7 @@ const DrawingLayer = ({
       updateTilemapLayer()
     },
 
-    magnifyingGlass: ({ x, y }) => {
+    inspector: ({ x, y }) => {
       const tileId = getTilemapPoint(x, y)
       const tilemapPointInfos = {
         message: `Tile ${fromSchemeGetTileNameById(scheme)(tileId)} (${tileId})`,

--- a/brush/src/components/MapActionsBar/SwitchTool.js
+++ b/brush/src/components/MapActionsBar/SwitchTool.js
@@ -8,8 +8,8 @@ const SwitchTool = ({ setToolState, toolState }) => (
     onChange={(value) => { setToolState(value) }}
     options={[
       {
-        title: 'Magnifying Glass',
-        value: 'magnifyingGlass',
+        title: 'Inspector',
+        value: 'inspector',
       },
       {
         title: 'Brush',

--- a/brush/src/hooks/useTool.js
+++ b/brush/src/hooks/useTool.js
@@ -2,10 +2,10 @@ import { useState } from 'react'
 
 const useTool = () => {
   const [{ currentTool, toolsValue }, setToolsStates] = useState({
-    currentTool: 'magnifyingGlass',
+    currentTool: 'inspector',
     toolsValue: {
       brush: null,
-      magnifyingGlass: null,
+      inspector: null,
     },
   })
 


### PR DESCRIPTION
Rename the tool `magnifying glass` to `inspector`, that is a more expressive one

![image](https://user-images.githubusercontent.com/9501115/64903858-27f0a980-d697-11e9-9a1d-6aeebab2004e.png)
