### PR TITLE
tilemap: fix overflow

### DIFF
--- a/brush/src/components/Map/index.js
+++ b/brush/src/components/Map/index.js
@@ -55,7 +55,7 @@ const Map = ({
 
   return (
     <Fragment>
-      <div className={style.canvasWrapper}>
+      <div className={style.webglWrapper}>
         <Stage
           width={(width * 4) + resolution} //   workaround because, for some unknown reason, we need to update the size of the stage when we change its resolution
           height={(height * 4) + resolution} // https://github.com/inlet/react-pixi/issues/127

--- a/brush/src/components/Map/index.js
+++ b/brush/src/components/Map/index.js
@@ -10,6 +10,7 @@ import OAMLayer from './OAMLayer'
 import PortalsLayer from './PortalsLayer'
 import GridLayer from './GridLayer'
 import useWhenVisionChanges from '../../hooks/useWhenVisionChanges'
+import style from './style.css'
 
 const Map = ({
   highlightCoordinates,
@@ -54,48 +55,50 @@ const Map = ({
 
   return (
     <Fragment>
-      <Stage
-        width={(width * 4) + resolution} //   workaround because, for some unknown reason, we need to update the size of the stage when we change its resolution
-        height={(height * 4) + resolution} // https://github.com/inlet/react-pixi/issues/127
-        options={{
+      <div className={style.canvasWrapper}>
+        <Stage
+          width={(width * 4) + resolution} //   workaround because, for some unknown reason, we need to update the size of the stage when we change its resolution
+          height={(height * 4) + resolution} // https://github.com/inlet/react-pixi/issues/127
+          options={{
           antialias: true,
           resolution,
           transparent: true,
-        }}
-        onMount={setPixiApplication}
-      >
-        <TilemapLayer
-          vision={vision}
-          ref={tilemapLayerRef}
-        />
-        <DrawingLayer
-          getTilemapPoint={getTilemapPoint}
-          height={height * 4}
-          resolution={resolution}
-          scheme={scheme}
-          setSelectedPointInfos={setSelectedPointInfos}
-          toolState={toolState}
-          updateTilemapLayer={() => tilemapLayerRef.current.forceUpdate()}
-          updateTilemapPoint={updateTilemapPoint}
-          width={width * 4}
-        />
-        {optShowOAM && <OAMLayer
-          updateOAMDiffMap={updateOAMDiffMap}
-          setSelectedPointInfos={setSelectedPointInfos}
-          totalStages={totalStages}
-          vision={vision}
-        />}
-        {optShowPortals && <PortalsLayer vision={vision} />}
-        <HighlightCoordinates
-          coordinates={highlightCoordinates}
-          height={height}
-          width={width}
-        />
-        {optShowGrid && <GridLayer
-          height={height * 4}
-          width={width * 4}
-        />}
-      </Stage>
+          }}
+          onMount={setPixiApplication}
+        >
+          <TilemapLayer
+            vision={vision}
+            ref={tilemapLayerRef}
+          />
+          <DrawingLayer
+            getTilemapPoint={getTilemapPoint}
+            height={height * 4}
+            resolution={resolution}
+            scheme={scheme}
+            setSelectedPointInfos={setSelectedPointInfos}
+            toolState={toolState}
+            updateTilemapLayer={() => tilemapLayerRef.current.forceUpdate()}
+            updateTilemapPoint={updateTilemapPoint}
+            width={width * 4}
+          />
+          {optShowOAM && <OAMLayer
+            updateOAMDiffMap={updateOAMDiffMap}
+            setSelectedPointInfos={setSelectedPointInfos}
+            totalStages={totalStages}
+            vision={vision}
+          />}
+          {optShowPortals && <PortalsLayer vision={vision} />}
+          <HighlightCoordinates
+            coordinates={highlightCoordinates}
+            height={height}
+            width={width}
+          />
+          {optShowGrid && <GridLayer
+            height={height * 4}
+            width={width * 4}
+          />}
+        </Stage>
+      </div>
       <MapFooter informations={selectedPointInfos} />
     </Fragment>
   )

--- a/brush/src/components/Map/style.css
+++ b/brush/src/components/Map/style.css
@@ -1,3 +1,3 @@
-.canvasWrapper {
+.webglWrapper {
   overflow-x: auto;
 }

--- a/brush/src/components/Map/style.css
+++ b/brush/src/components/Map/style.css
@@ -1,0 +1,3 @@
+.canvasWrapper {
+  overflow-x: auto;
+}


### PR DESCRIPTION
This PR fixes #14.

I used a div to wrap the Pixi's Stage component and set auto-scrolling.
Setting scroll options on the canvas or the map card didn't work as intended.

![Screenshot from 2019-10-05 19-53-53](https://user-images.githubusercontent.com/1427376/66262109-7a157e00-e7b0-11e9-85cc-c1cfd7facdab.png)