### PR TITLE
objects: refac renaming oam -> object

### DIFF
--- a/brush/src/components/KloGbaSidebar/DisplayMapOptions/index.js
+++ b/brush/src/components/KloGbaSidebar/DisplayMapOptions/index.js
@@ -24,11 +24,11 @@ const DisplayMapOptions = () => {
           onChange={() => setOptions.setShowGrid(!options.showGrid)}
         />
         <Checkbox
-          label="Show OAM"
-          name="optShowOAM"
-          value={`${options.showOAM}`}
-          checked={options.showOAM}
-          onChange={() => setOptions.setShowOAM(!options.showOAM)}
+          label="Show Objects"
+          name="optShowObjects"
+          value={`${options.showObjects}`}
+          checked={options.showObjects}
+          onChange={() => setOptions.setShowObjects(!options.showObjects)}
         />
         <Checkbox
           label="Show Portals"

--- a/brush/src/components/Map/HighlightCoordinates/index.js
+++ b/brush/src/components/Map/HighlightCoordinates/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import { Graphics } from '@inlet/react-pixi'
 
 const SIZE = 4
-const OAM_SCALE = 8
+const OBJECTS_SCALE = 8
 
 const HighlightCoordinates = ({
   coordinates,
@@ -11,8 +11,8 @@ const HighlightCoordinates = ({
   width,
 }) => {
   const [x, y] = coordinates
-  const xScaled = ((x * SIZE) / OAM_SCALE) - 2
-  const yScaled = ((y * SIZE) / OAM_SCALE) - 2
+  const xScaled = ((x * SIZE) / OBJECTS_SCALE) - 2
+  const yScaled = ((y * SIZE) / OBJECTS_SCALE) - 2
 
   return (
     <Graphics

--- a/brush/src/components/Map/ObjectsLayer/index.js
+++ b/brush/src/components/Map/ObjectsLayer/index.js
@@ -1,29 +1,29 @@
 import React, { Fragment } from 'react'
 import PropTypes from 'prop-types'
 import { range } from 'ramda'
-import PointOam from '../Point/PointOam'
+import PointObject from '../Point/PointObject'
 
-const OAMLayer = ({
+const ObjectsLayer = ({
   setSelectedPointInfos,
   totalStages,
-  updateOAMDiffMap,
+  updateObjectsDiffMap,
   vision,
 }) => {
-  const { oam } = vision
+  const { objects } = vision
 
-  const oamList = oam
-    .map(oamEntry => oamEntry.data)
-    .map((oamData, oamIndex) =>
+  const objectsList = objects
+    .map(objectEntry => objectEntry.data)
+    .map((objectData, objectIndex) =>
       range(1, totalStages + 1).map((i) => {
-        const x = oamData[`xStage${i}`]
-        const y = oamData[`yStage${i}`]
+        const x = objectData[`xStage${i}`]
+        const y = objectData[`yStage${i}`]
 
         return (
-          <PointOam
-            onFinishDragAndDrop={updateOAMDiffMap}
+          <PointObject
+            onFinishDragAndDrop={updateObjectsDiffMap}
             key={`${x} ${y} ${i}`}
-            oamId={oamData.kind}
-            oamIndex={oamIndex}
+            objectId={objectData.kind}
+            objectIndex={objectIndex}
             stage={i}
             showPointInfosHandle={setSelectedPointInfos}
             x={x}
@@ -34,26 +34,26 @@ const OAMLayer = ({
 
   return (
     <Fragment>
-      {oamList}
+      {objectsList}
     </Fragment>
   )
 }
 
-OAMLayer.propTypes = {
+ObjectsLayer.propTypes = {
   setSelectedPointInfos: PropTypes.func,
   totalStages: PropTypes.number.isRequired,
-  updateOAMDiffMap: PropTypes.func,
+  updateObjectsDiffMap: PropTypes.func,
   vision: PropTypes.shape({
-    oam: PropTypes.arrayOf(PropTypes.shape({
+    objects: PropTypes.arrayOf(PropTypes.shape({
       data: PropTypes.object.isRequired,
       memory: PropTypes.object.isRequired,
     })).isRequired,
   }).isRequired,
 }
 
-OAMLayer.defaultProps = {
+ObjectsLayer.defaultProps = {
   setSelectedPointInfos: () => {},
-  updateOAMDiffMap: () => {},
+  updateObjectsDiffMap: () => {},
 }
 
-export default OAMLayer
+export default ObjectsLayer

--- a/brush/src/components/Map/Point/PointObject.js
+++ b/brush/src/components/Map/Point/PointObject.js
@@ -1,10 +1,10 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { defaultTo, pipe } from 'ramda'
-import { oamIdToName } from 'scissors'
+import { objectIdToName } from 'scissors'
 import Point from '.'
 
-const oamIdToColor = {
+const objectIdToColor = {
   0x01: [0xBC1616, 1],
   0x02: [0x1616BC, 1],
   0x03: [0xFFE80D, 1],
@@ -19,27 +19,27 @@ const oamIdToColor = {
   0x78: [0x21722B, 1],
 }
 
-const PointOam = ({
-  oamId,
-  oamIndex,
+const PointObject = ({
+  objectId,
+  objectIndex,
   onFinishDragAndDrop,
   showPointInfosHandle,
   stage,
   x,
   y,
 }) => {
-  const name = defaultTo('unknown', oamIdToName[oamId])
-  const color = defaultTo([0x000000, 1], oamIdToColor[oamId])
+  const name = defaultTo('unknown', objectIdToName[objectId])
+  const color = defaultTo([0x000000, 1], objectIdToColor[objectId])
 
   const getInformations = () => ({
-    message: `OAM ${name} (${oamId}) from stage ${stage}`,
+    message: `Object ${name} (${objectId}) from stage ${stage}`,
     x,
     y,
   })
 
-  const saveNewOAMPosition = (newX, newY) => {
-    onFinishDragAndDrop(oamIndex, `xStage${stage}`, newX)
-    onFinishDragAndDrop(oamIndex, `yStage${stage}`, newY)
+  const saveNewObjectPosition = (newX, newY) => {
+    onFinishDragAndDrop(objectIndex, `xStage${stage}`, newX)
+    onFinishDragAndDrop(objectIndex, `yStage${stage}`, newY)
   }
 
   return (<Point
@@ -47,16 +47,16 @@ const PointOam = ({
     draggable
     hasStroke
     onHoverHandle={pipe(getInformations, showPointInfosHandle)}
-    onFinishDragAndDropHandle={saveNewOAMPosition}
+    onFinishDragAndDropHandle={saveNewObjectPosition}
     scale={8}
     x={x}
     y={y}
   />)
 }
 
-PointOam.propTypes = {
-  oamId: PropTypes.number.isRequired,
-  oamIndex: PropTypes.number.isRequired,
+PointObject.propTypes = {
+  objectId: PropTypes.number.isRequired,
+  objectIndex: PropTypes.number.isRequired,
   onFinishDragAndDrop: PropTypes.func,
   showPointInfosHandle: PropTypes.func,
   stage: PropTypes.number.isRequired,
@@ -64,9 +64,9 @@ PointOam.propTypes = {
   y: PropTypes.number.isRequired,
 }
 
-PointOam.defaultProps = {
+PointObject.defaultProps = {
   onFinishDragAndDrop: () => {},
   showPointInfosHandle: () => {},
 }
 
-export default PointOam
+export default PointObject

--- a/brush/src/components/Map/index.js
+++ b/brush/src/components/Map/index.js
@@ -12,7 +12,7 @@ import HighlightCoordinates from './HighlightCoordinates'
 import VisionContext from '../../context/VisionContext'
 import TilemapLayer from './TilemapLayer'
 import DrawingLayer from './DrawingLayer'
-import OAMLayer from './OAMLayer'
+import ObjectsLayer from './ObjectsLayer'
 import PortalsLayer from './PortalsLayer'
 import GridLayer from './GridLayer'
 import useWhenVisionChanges from '../../hooks/useWhenVisionChanges'
@@ -21,14 +21,14 @@ import style from './style.css'
 const Map = ({
   highlightCoordinates,
   optShowGrid,
-  optShowOAM,
+  optShowObjects,
   optShowPortals,
   resolution,
   toolState,
 }) => {
   const {
     getTilemapPoint,
-    updateOAMDiffMap,
+    updateObjectsDiffMap,
     updateTilemapPoint,
     vision,
   } = useContext(VisionContext)
@@ -92,8 +92,8 @@ const Map = ({
             updateTilemapPoint={updateTilemapPoint}
             width={width * 4}
           />
-          {optShowOAM && <OAMLayer
-            updateOAMDiffMap={updateOAMDiffMap}
+          {optShowObjects && <ObjectsLayer
+            updateObjectsDiffMap={updateObjectsDiffMap}
             setSelectedPointInfos={setSelectedPointInfos}
             totalStages={totalStages}
             vision={vision}
@@ -118,7 +118,7 @@ const Map = ({
 Map.propTypes = {
   highlightCoordinates: PropTypes.arrayOf(PropTypes.number),
   optShowGrid: PropTypes.bool,
-  optShowOAM: PropTypes.bool,
+  optShowObjects: PropTypes.bool,
   optShowPortals: PropTypes.bool,
   resolution: PropTypes.number,
   toolState: PropTypes.shape({
@@ -130,7 +130,7 @@ Map.propTypes = {
 Map.defaultProps = {
   highlightCoordinates: [-1, -1],
   optShowGrid: false,
-  optShowOAM: true,
+  optShowObjects: true,
   optShowPortals: true,
   resolution: 1,
 }

--- a/brush/src/components/MapActionsBar/SaveButton.js
+++ b/brush/src/components/MapActionsBar/SaveButton.js
@@ -4,13 +4,15 @@ import { saveVision } from 'scissors'
 import ROMContext from '../../context/ROMContext'
 import VisionContext from '../../context/VisionContext'
 
-const romDownload = (romBufferMemory, world, index, tilemap, oamDiffMap) => {
+const romDownload = (
+  romBufferMemory, world, index, tilemap, objectsDiffMap
+) => {
   const newMemoryROM = saveVision(
     romBufferMemory,
     world,
     index,
     tilemap,
-    oamDiffMap
+    objectsDiffMap
   )
 
   const blob = new Blob([newMemoryROM])
@@ -30,7 +32,7 @@ const SaveButton = () => {
   const { romBufferMemory } = useContext(ROMContext)
   const {
     vision: {
-      oamDiffMap,
+      objectsDiffMap,
       state,
       tilemap,
     },
@@ -46,7 +48,7 @@ const SaveButton = () => {
           visionWorld,
           visionIndex,
           tilemap,
-          oamDiffMap
+          objectsDiffMap
         )
       }}
       disabled={state === 'noSelected'}

--- a/brush/src/components/ObjectsTable/index.js
+++ b/brush/src/components/ObjectsTable/index.js
@@ -1,15 +1,15 @@
 import React, { useContext } from 'react'
 import PropTypes from 'prop-types'
 import { Table } from 'former-kit'
-import { oamIdToName } from 'scissors'
+import { objectIdToName } from 'scissors'
 import { defaultTo } from 'ramda'
 import VisionContext from '../../context/VisionContext'
 
 const ObjectsTable = ({ onRowClickHandler }) => {
-  const { oam } = useContext(VisionContext).vision
+  const { objects } = useContext(VisionContext).vision
 
-  const rows = oam
-    .map(oamEntry => oamEntry.data)
+  const rows = objects
+    .map(objectEntry => objectEntry.data)
     .map(({
       kind,
       xStage1,
@@ -19,7 +19,7 @@ const ObjectsTable = ({ onRowClickHandler }) => {
       yStage2,
       yStage3,
     }) => {
-      const name = defaultTo('unknown', oamIdToName[kind])
+      const name = defaultTo('unknown', objectIdToName[kind])
 
       return [
         {

--- a/brush/src/pages/Main/LoadedRom.js
+++ b/brush/src/pages/Main/LoadedRom.js
@@ -47,7 +47,7 @@ const LoadedRom = () => {
               <Map
                 highlightCoordinates={highlightCoordinates}
                 optShowGrid={options.showGrid}
-                optShowOAM={options.showOAM}
+                optShowObjects={options.showObjects}
                 optShowPortals={options.showPortals}
                 toolState={toolState}
                 resolution={options.zoom}

--- a/brush/src/providers/DisplayMapOptionsProvider.js
+++ b/brush/src/providers/DisplayMapOptionsProvider.js
@@ -5,7 +5,7 @@ import DisplayMapOptionsContext from '../context/DisplayMapOptionsContext'
 const DisplayMapOptionsProvider = ({ children }) => {
   const [zoom, setZoom] = useState(1)
   const [showGrid, setShowGrid] = useState(false)
-  const [showOAM, setShowOAM] = useState(true)
+  const [showObjects, setShowObjects] = useState(true)
   const [showPortals, setShowPortals] = useState(true)
 
   return (
@@ -13,13 +13,13 @@ const DisplayMapOptionsProvider = ({ children }) => {
       value={{
         options: {
           showGrid,
-          showOAM,
+          showObjects,
           showPortals,
           zoom,
         },
         setOptions: {
           setShowGrid,
-          setShowOAM,
+          setShowObjects,
           setShowPortals,
           setZoom,
         },

--- a/brush/src/providers/VisionProvider.js
+++ b/brush/src/providers/VisionProvider.js
@@ -9,8 +9,8 @@ const VisionProvider = ({ children }) => {
 
   const emptyState = {
     infos: { index: 0, tilemap: { height: 0, scheme: [], width: 0 }, world: 0 },
-    oam: [],
-    oamDiffMap: {},
+    objects: [],
+    objectsDiffMap: {},
     state: 'noSelected',
     tilemap: new Uint8Array(),
   }
@@ -27,7 +27,7 @@ const VisionProvider = ({ children }) => {
     newVision.state = 'selected'
     newVision.infos.world = world
     newVision.infos.index = index
-    newVision.oamDiffMap = {}
+    newVision.objectsDiffMap = {}
     setVision(newVision)
   }
 
@@ -38,19 +38,19 @@ const VisionProvider = ({ children }) => {
   const getTilemapPoint = (x, y) =>
     vision.tilemap[x + (y * vision.infos.tilemap.width)]
 
-  const updateOAMDiffMap = (index, key, value) => {
-    if (vision.oamDiffMap[index] === undefined) {
-      vision.oamDiffMap[index] = {}
+  const updateObjectsDiffMap = (index, key, value) => {
+    if (vision.objectsDiffMap[index] === undefined) {
+      vision.objectsDiffMap[index] = {}
     }
 
-    vision.oamDiffMap[index][key] = value
+    vision.objectsDiffMap[index][key] = value
   }
 
   return (
     <VisionContext.Provider value={{
       getTilemapPoint,
       setEmptyState,
-      updateOAMDiffMap,
+      updateObjectsDiffMap,
       updateTilemapPoint,
       updateVision,
       vision,

--- a/scissors/src/index.js
+++ b/scissors/src/index.js
@@ -1,5 +1,5 @@
 import { getVision, saveVision } from './visionManager'
-import { oamIdToName } from './oamMaps'
+import { objectIdToName } from './objectMaps'
 import fromSchemeGetTileNameById from './fromSchemeGetTileNameById'
 import { getRomRegion, supportedRomRegions, isSupportedRegion } from './romRegion'
 import { allVisions } from './visions'
@@ -8,7 +8,7 @@ export {
   allVisions,
   fromSchemeGetTileNameById,
   getVision,
-  oamIdToName,
+  objectIdToName,
   saveVision,
   getRomRegion,
   supportedRomRegions,

--- a/scissors/src/objectMaps.js
+++ b/scissors/src/objectMaps.js
@@ -1,4 +1,4 @@
-const oamIdToName = {
+const objectIdToName = {
   0x01: 'redKey',
   0x02: 'blueKey',
   0x03: 'star',
@@ -13,4 +13,4 @@ const oamIdToName = {
   0x78: 'flyingMooVerical',
 }
 
-export { oamIdToName } // eslint-disable-line import/prefer-default-export
+export { objectIdToName } // eslint-disable-line import/prefer-default-export

--- a/scissors/src/visions/1-1.js
+++ b/scissors/src/visions/1-1.js
@@ -7,7 +7,7 @@ export default {
   rom: {
     tilemap: [0x1B27FC, 0x1B36F3],
     customTilemap: [0x367700, 0x3686AF],
-    oam: [0xE2B90, 0xE2F59],
+    objects: [0xE2B90, 0xE2F59],
     portals: [0xD48C8, 0xD48EF],
   },
   tilemap: {

--- a/scissors/src/visions/1-2.js
+++ b/scissors/src/visions/1-2.js
@@ -7,7 +7,7 @@ export default {
   rom: {
     tilemap: [0x1B3E5C, 0x1B4AC3],
     customTilemap: [0x3686B0, 0x36937F],
-    oam: [0xE3CC0, 0xE3FAC],
+    objects: [0xE3CC0, 0xE3FAC],
     portals: [0xD4970, 0xD49A0],
   },
   tilemap: {

--- a/scissors/src/visions/1-3.js
+++ b/scissors/src/visions/1-3.js
@@ -7,7 +7,7 @@ export default {
   rom: {
     tilemap: [0x1B50AC, 0x1B5ECC],
     customTilemap: [0x369380, 0x36A220],
-    oam: [0xE4DF0, 0xE5109],
+    objects: [0xE4DF0, 0xE5109],
     portals: [0xD4A18, 0xD4A5F],
   },
   tilemap: {


### PR DESCRIPTION
Rename `OAM` to `Object`.
Initially I named it was `OAM` in order to not confuse with JS' objects, but it was a bad decision, because `OAM` is the abbreviation for `Object Attribute Memory`... a region of memory on Gameboy Advance, not a specific object on the game.