### PR TITLE
visions: remove end address for tilemaps

### DIFF
--- a/scissors/src/rom.js
+++ b/scissors/src/rom.js
@@ -12,7 +12,7 @@ const isCustomRom = (romBuffer) => {
 }
 
 const visionHasCustomTilemap = (romBuffer, visionInfo) =>
-  romBuffer[visionInfo.rom.customTilemap[0]] !== 0x00
+  romBuffer[visionInfo.rom.customTilemap] !== 0x00
 
 const setConstant = (romBuffer, address, value24hexLength) => {
   const bytes = splitHexValueIntoBytesArray(value24hexLength, 4)
@@ -24,8 +24,8 @@ const setPatchCustomVisionLoader = (romBuffer) => {
     visionHasCustomTilemap(romBuffer, visionInfo))
 
   const addresses = allVisions.map(visionInfo => ({
-    custom: mapAddressToRomOffset(visionInfo.rom.customTilemap[0]),
-    original: mapAddressToRomOffset(visionInfo.rom.tilemap[0]),
+    custom: mapAddressToRomOffset(visionInfo.rom.customTilemap),
+    original: mapAddressToRomOffset(visionInfo.rom.tilemap),
   }))
 
   // set bl to go to our patch

--- a/scissors/src/visionManager.js
+++ b/scissors/src/visionManager.js
@@ -22,8 +22,8 @@ import {
 
 const isNumeric = pipe(t => Number(t), identical(NaN), not)
 
-const extractFullTilemap = (romBuffer, [addressStart, addressEnd]) =>
-  romBuffer.slice(addressStart, addressEnd)
+const extractFullTilemap = (romBuffer, addressStart) =>
+  romBuffer.slice(addressStart)
   |> huffmanDecode
   |> lzssDecode
 
@@ -71,14 +71,14 @@ const extractPortals = (romBuffer, [addressStart, addressEnd]) =>
 
 const getVision = (romBuffer, world, vision) => {
   const infos = loadVisionInfo(world, vision)
-  const range = visionHasCustomTilemap(romBuffer, infos) ?
+  const addressStart = visionHasCustomTilemap(romBuffer, infos) ?
     infos.rom.customTilemap :
     infos.rom.tilemap
 
   // The first 3 bytes of tilemap isn't the tiles,
   // but something unknown important to plot the level at the game.
   // So this proxy is useful to abstract Brush about this detail
-  const fullTilemap = extractFullTilemap(romBuffer, range)
+  const fullTilemap = extractFullTilemap(romBuffer, addressStart)
 
   const tilemapProxy = new Proxy(fullTilemap, {
     get: (target, property) => {
@@ -170,7 +170,7 @@ const compressTilemap = buffer =>
 
 const saveVision = (romBuffer, world, index, tilemap, objectsDiffsMap) => {
   const infos = loadVisionInfo(world, index)
-  const [customTilemapStartAddress] = infos.rom.customTilemap
+  const customTilemapStartAddress = infos.rom.customTilemap
   const [objectsStartAddress] = infos.rom.objects
 
   const encoded = compressTilemap(tilemap)

--- a/scissors/src/visions/1-1.js
+++ b/scissors/src/visions/1-1.js
@@ -5,8 +5,8 @@ export default {
     index: 1,
   },
   rom: {
-    tilemap: [0x1B27FC, 0x1B36F3],
-    customTilemap: [0x367700, 0x3686AF],
+    tilemap: 0x1B27FC,
+    customTilemap: 0x367700,
     objects: [0xE2B90, 0xE2F59],
     portals: [0xD48C8, 0xD48EF],
   },

--- a/scissors/src/visions/1-2.js
+++ b/scissors/src/visions/1-2.js
@@ -5,8 +5,8 @@ export default {
     index: 2,
   },
   rom: {
-    tilemap: [0x1B3E5C, 0x1B4AC3],
-    customTilemap: [0x3686B0, 0x36937F],
+    tilemap: 0x1B3E5C,
+    customTilemap: 0x3686B0,
     objects: [0xE3CC0, 0xE3FAC],
     portals: [0xD4970, 0xD49A0],
   },

--- a/scissors/src/visions/1-3.js
+++ b/scissors/src/visions/1-3.js
@@ -5,8 +5,8 @@ export default {
     index: 3,
   },
   rom: {
-    tilemap: [0x1B50AC, 0x1B5ECC],
-    customTilemap: [0x369380, 0x36A220],
+    tilemap: 0x1B50AC,
+    customTilemap: 0x369380,
     objects: [0xE4DF0, 0xE5109],
     portals: [0xD4A18, 0xD4A5F],
   },


### PR DESCRIPTION
This value is unnecessary, because the uncompress algorithm can infer when the blob ends.
Removing it became easier to write the file vision.