### PR TITLE
chore: bump react-gbajs to 1.0.0

### DIFF
--- a/brush/package.json
+++ b/brush/package.json
@@ -26,7 +26,7 @@
     "react": "16.10.2",
     "react-dom": "16.10.2",
     "react-file-reader-input": "2.0.0",
-    "react-gbajs": "0.0.1",
+    "react-gbajs": "1.0.0",
     "pixi.js": "5.1.5",
     "@inlet/react-pixi": "1.1.2",
     "scissors": "*"

--- a/brush/src/components/Emulator/index.js
+++ b/brush/src/components/Emulator/index.js
@@ -1,23 +1,44 @@
-import React, { useEffect, useContext } from 'react'
+import React, { useEffect, useContext, useState } from 'react'
 import GBAEmulator, { GbaContext } from 'react-gbajs'
 import useGbaSaveRestoreState from '../../hooks/useGbaSaveRestoreState'
 import ROMContext from '../../context/ROMContext'
 
 const Emulator = () => {
+  const [onError, setOnError] = useState(false)
   const { play: playGba } = useContext(GbaContext)
   const { romBufferMemory, romBufferStatus } = useContext(ROMContext)
 
   useEffect(() => {
+    setOnError(false)
+
     if (romBufferStatus === 'loaded') {
-      playGba(romBufferMemory)
+      playGba({ newRomBuffer: romBufferMemory })
     }
   }, [romBufferStatus]) /* should not be called when romBufferState.memory updates */ // eslint-disable-line react-hooks/exhaustive-deps
 
   useGbaSaveRestoreState()
 
+  const handleEmulatorCrashed = (...error) => {
+    setOnError(true)
+
+    // eslint-disable-next-line no-console
+    console.warn(error)
+  }
+
+  if (onError) {
+    return (
+      <span>
+        Emulator crashed. Please, open a new ROM or refresh this page.
+      </span>
+    )
+  }
+
   return (
     <>
-      <GBAEmulator volume={0} />
+      <GBAEmulator
+        scale={2}
+        onLogReceived={handleEmulatorCrashed}
+      />
       <span>
         Controls:{' '}
         <strong>z</strong> → a;{' '}

--- a/brush/src/hooks/useGbaSaveRestoreState.js
+++ b/brush/src/hooks/useGbaSaveRestoreState.js
@@ -12,8 +12,8 @@ const keyCodeToAction = ({
 const useGbaSaveRestoreState = () => {
   const [savedState, setSavedState] = useState()
   const {
+    play,
     saveState,
-    updateState,
   } = useContext(GbaContext)
 
   useEffect(() => {
@@ -25,7 +25,7 @@ const useGbaSaveRestoreState = () => {
       }
 
       if (action === 'restore' && savedState !== undefined) {
-        updateState({ restoreState: savedState })
+        play({ restoreState: savedState })
       }
     }
 
@@ -36,7 +36,7 @@ const useGbaSaveRestoreState = () => {
       window.removeEventListener('keydown', switchHandle)
       window.removeEventListener('keyup', switchHandle)
     }
-  }, [savedState, updateState, saveState])
+  }, [savedState, play, saveState])
 }
 
 export default useGbaSaveRestoreState

--- a/brush/src/providers/VisionProvider.js
+++ b/brush/src/providers/VisionProvider.js
@@ -6,7 +6,7 @@ import VisionContext from '../context/VisionContext'
 import useForceUpdate from '../hooks/useForceUpdate'
 
 const VisionProvider = ({ children }) => {
-  const { updateState } = useContext(GbaContext)
+  const { play } = useContext(GbaContext)
 
   const [visionWorld, setVisionWorld] = useState(1)
   const [visionIndex, setVisionIndex] = useState(1)
@@ -38,7 +38,7 @@ const VisionProvider = ({ children }) => {
   }
 
   const gbaEnterVision = (world, index, newRomBuffer = undefined) =>
-    updateState({
+    play({
       newRomBuffer,
       restoreState: enteringVisionGbaState(world, index),
     })

--- a/yarn.lock
+++ b/yarn.lock
@@ -7545,16 +7545,15 @@ react-file-reader-input@2.0.0:
   resolved "https://registry.yarnpkg.com/react-file-reader-input/-/react-file-reader-input-2.0.0.tgz#44d2a466731d2cc3f51dee9970f204585742243b"
   integrity sha512-1XgkCpwMnNQsuOIy938UCntz8Xzwt9ECwHaH3cCfIQK1SPpH+y7gCYtqEcb6Rm0hAUq7Lp9+Ljoti9zGMswYrQ==
 
-react-gbajs@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/react-gbajs/-/react-gbajs-0.0.1.tgz#d1c5186669faf839b44fea4fbdd706bb6337d8bd"
-  integrity sha512-yl/LQqc1oOti5YwHXBytoZM7nYaOEJW5YGdZ/o6n5u8upgAJFj5Yq77dX2NLa86aChchhU0F8Ie/HLcktMWoog==
+react-gbajs@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/react-gbajs/-/react-gbajs-1.0.0.tgz#971789b90f825b51168c5f6e750c01490781c380"
+  integrity sha512-QQXF/qVuPrSwYWhFW0d6o/1MLCSu8GIcVsPdGpbhkml2YnHAgHXDIDeGM/M9OfITv68z3MD1hZnl8nxt+e/6FA==
   dependencies:
     "@babel/plugin-transform-runtime" "7.6.2"
     "@babel/polyfill" "7.7.0"
     "@babel/runtime" "7.7.2"
     lodash.clonedeep "4.5.0"
-    prop-types "15.7.2"
 
 react-input-mask@2.0.4:
   version "2.0.4"


### PR DESCRIPTION
Bump `react-gbajs` to 1.0.0: https://github.com/macabeus/react-gbajs/releases/tag/1.0.0