### PR TITLE
Small improvements

### DIFF
--- a/brush/src/components/Map/DrawingLayer/index.js
+++ b/brush/src/components/Map/DrawingLayer/index.js
@@ -27,6 +27,12 @@ const DrawingLayer = ({
 
     eyedropper: ({ x, y }) => {
       const tileId = getTilemapPoint(x, y)
+
+      if (tileId === 0x00) {
+        setToolState('eraser')
+        return
+      }
+
       setToolState('brush', tileId)
     },
 

--- a/brush/src/components/Map/ObjectsLayer/index.js
+++ b/brush/src/components/Map/ObjectsLayer/index.js
@@ -11,6 +11,8 @@ const ObjectsLayer = ({
   setSelectedPointInfos,
   totalStages,
   updateObjectsDiffMap,
+  world,
+  index,
   vision,
 }) => {
   const {
@@ -98,7 +100,7 @@ const ObjectsLayer = ({
                 mapObjectKindToRelativePositions
               }
               onObjectSelected={setSelectedObject}
-              key={`${x} ${y} ${i}`}
+              key={`${world} ${index} ${x} ${y} ${i}`}
             />
           )
         }
@@ -108,7 +110,7 @@ const ObjectsLayer = ({
         return (
           <PointObject
             onFinishDragAndDrop={updateObjectsDiffMap}
-            key={`${x} ${y} ${i}`}
+            key={`${world} ${index} ${x} ${y} ${i}`}
             objectId={objectData.kind}
             objectIndex={objectIndex}
             stage={i}


### PR DESCRIPTION
Three small improvements:
- if selects a blank tile using the eyedropper tool, the active tool will be the eraser instead of the brush
- add a square cursor when hovering the drawing layer
- fix bug when react cached an object component from the previous selected vision